### PR TITLE
fix(mcu): endianness aware mcu command structure

### DIFF
--- a/libloragw/inc/loragw_aux.h
+++ b/libloragw/inc/loragw_aux.h
@@ -46,6 +46,15 @@ void wait_ns_linux(unsigned long t);
 void wait_ms(unsigned long t);
 void wait_ns(unsigned long t);
 
+/**
+ * @brief Copys src to dst in little endian format.
+ * @param dest destination memory pointer
+ * @param src source memory pointer
+ * @param n number of bytes to copy
+ * @return pointer to the destination memory
+ */
+void *memcpy_le(void *dest, void *src, size_t n);
+
 #endif
 
 /* --- EOF ------------------------------------------------------------------ */

--- a/libloragw/src/loragw_aux.c
+++ b/libloragw/src/loragw_aux.c
@@ -26,6 +26,7 @@ License: Revised BSD License, see LICENSE.TXT file include in the project
 
 #include <stdio.h>  /* printf fprintf */
 #include <time.h>   /* clock_nanosleep */
+#include <stdint.h> /* uint8_t */
 
 /* -------------------------------------------------------------------------- */
 /* --- PRIVATE MACROS ------------------------------------------------------- */
@@ -106,5 +107,18 @@ void wait_ns(unsigned long a) {
     DEBUG_PRINTF("System is not recognized.");
 #endif
 }
+
+void *memcpy_le(void *dest, void *src, size_t n)
+{
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    return memcpy(dest, src, n);
+#else
+    for (size_t i = 0; i < n; i++)
+        ((uint8_t *)dest)[i] = ((uint8_t *)src)[n - 1 - i];
+
+    return dest;
+#endif
+}
+
 
 /* --- EOF ------------------------------------------------------------------ */


### PR DESCRIPTION
Currently only little-endian hosts are supported because of the way multi-byte values get transferred to the MCU. Running libloragw on big-endian hosts is therefore a problem.